### PR TITLE
Added possible simple donate page with a quick link in the footer

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -27,6 +27,7 @@
                 </template>
               </IDropdown>
               <INavItem to="/book-store" exact-active-class="-active">Book Store</INavItem>
+              <INavItem to="/donate" exact-active-class="-active">Donate</INavItem>
             </INav>
             <div class="action-buttons">
               <IButton link color="primary" to="/stay-connected">
@@ -73,6 +74,9 @@
                   </li>
                   <li>
                     <a href="/book-store/">Book Store</a>
+                  </li>
+                  <li>
+                    <a href="/donate/">Donate</a>
                   </li>
                 </ul>
               </div>

--- a/pages/donate/index.vue
+++ b/pages/donate/index.vue
@@ -1,0 +1,16 @@
+<template>
+    <IContainer>
+      <SectionHeader>Donate</SectionHeader>
+      <div style="border: solid 1px #eee; padding: 8px">
+        <p>
+          The <strong>Pontian Greek Society of Chicago - XENITEAS</strong> is dedicated to preserving our rich heritage and uniting our community through cultural events and youth outreach.
+        </p>
+        <p>
+          Your generous contribution helps us honor our past, celebrate our traditions, and inspire the next generation.
+        </p>
+        <p>
+          Click <a href="https://placeholder.fornow" target="_blank" rel="noopener">here to make a donation</a> and support our efforts.
+        </p>
+      </div>
+    </IContainer>
+  </template>


### PR DESCRIPTION
- Added a new "Donate" page, pretty similar to the "Membership" page. 
- Added it to the header and added a quick link in the footer as well. 
- I do not have the link for Xeniteas' PayPal, so for now, I set the href="https://placeholder.fornow"
- This is just a mere concept of how the donation issue can be solved, but if there are better ways 
   of going about it, then that's fine too.